### PR TITLE
eventlib create_metric fix

### DIFF
--- a/packages/core/EventLib.cpp
+++ b/packages/core/EventLib.cpp
@@ -395,7 +395,8 @@ int32_t EventLib::registerMetric (const char* category, subtype_t subtype, const
         metric.subtype  = subtype;
         metric.name     = StringLib::duplicate(name_buf);
         metric.category = StringLib::duplicate(category);
-        metric.id       = metric_vals.add(metric);
+        metric.id       = metric_vals.length();
+        metric_vals.add(metric);
 
         /* Register Metric */
         if(ids->add(metric.name, metric.id, true))


### PR DESCRIPTION
valgrind detected a problem:

==3554747== Conditional jump or move depends on uninitialised value(s)
==3554747== at 0x1F6254: EventLib::generateMetric(int, event_level_t) (EventLib.cpp:488)