### PR TITLE
Minor improvements to H5Coro

### DIFF
--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -1968,18 +1968,19 @@ int H5FileBuffer::readMessage (msg_type_t msg_type, uint64_t size, uint64_t pos,
 {
     switch(msg_type)
     {
-        case DATASPACE_MSG:     return readDataspaceMsg(pos, hdr_flags, dlvl);
-        case LINK_INFO_MSG:     return readLinkInfoMsg(pos, hdr_flags, dlvl);
-        case DATATYPE_MSG:      return readDatatypeMsg(pos, hdr_flags, dlvl);
-        case FILL_VALUE_MSG:    return readFillValueMsg(pos, hdr_flags, dlvl);
-        case LINK_MSG:          return readLinkMsg(pos, hdr_flags, dlvl);
-        case DATA_LAYOUT_MSG:   return readDataLayoutMsg(pos, hdr_flags, dlvl);
-        case FILTER_MSG:        return readFilterMsg(pos, hdr_flags, dlvl);
+        case DATASPACE_MSG:       return readDataspaceMsg(pos, hdr_flags, dlvl);
+        case LINK_INFO_MSG:       return readLinkInfoMsg(pos, hdr_flags, dlvl);
+        case DATATYPE_MSG:        return readDatatypeMsg(pos, hdr_flags, dlvl);
+        case FILL_VALUE_MSG:      return readFillValueMsg(pos, hdr_flags, dlvl);
+        case LINK_MSG:            return readLinkMsg(pos, hdr_flags, dlvl);
+        case DATA_LAYOUT_MSG:     return readDataLayoutMsg(pos, hdr_flags, dlvl);
+        case FILTER_MSG:          return readFilterMsg(pos, hdr_flags, dlvl);
 #ifdef H5CORO_ATTRIBUTE_SUPPORT
-        case ATTRIBUTE_MSG:     return readAttributeMsg(pos, hdr_flags, dlvl, size);
+        case ATTRIBUTE_MSG:       return readAttributeMsg(pos, hdr_flags, dlvl, size);
+        case ATTRIBUTE_INFO_MSG:  return readAttributeInfoMsg(pos, hdr_flags, dlvl);
 #endif
-        case HEADER_CONT_MSG:   return readHeaderContMsg(pos, hdr_flags, dlvl);
-        case SYMBOL_TABLE_MSG:  return readSymbolTableMsg(pos, hdr_flags, dlvl);
+        case HEADER_CONT_MSG:     return readHeaderContMsg(pos, hdr_flags, dlvl);
+        case SYMBOL_TABLE_MSG:    return readSymbolTableMsg(pos, hdr_flags, dlvl);
 
         default:
         {
@@ -2800,6 +2801,73 @@ int H5FileBuffer::readAttributeMsg (uint64_t pos, uint8_t hdr_flags, int dlvl, u
 
     /* Move to End of Data */
     pos += metaData.size;
+
+    /* Return Bytes Read */
+    uint64_t ending_position = pos;
+    return ending_position - starting_position;
+}
+
+/*----------------------------------------------------------------------------
+ * readAttributeInfoMsg
+ *----------------------------------------------------------------------------*/
+int H5FileBuffer::readAttributeInfoMsg (uint64_t pos, uint8_t hdr_flags, int dlvl)
+{
+    static const int MAX_CREATE_PRESENT_BIT     = 0x01;
+    static const int CREATE_ORDER_PRESENT_BIT   = 0x02;
+
+    uint64_t starting_position = pos;
+
+    uint64_t version = readField(1, &pos);
+    uint64_t flags = readField(1, &pos);
+
+    if(errorChecking)
+    {
+        if(version != 0)
+        {
+            throw RunTimeException(CRITICAL, RTE_ERROR, "invalid link info version: %d", (int)version);
+        }
+    }
+
+    if(verbose)
+    {
+        print2term("\n----------------\n");
+        print2term("Attribute Information Message [%d], 0x%lx\n", dlvl, (unsigned long)starting_position);
+        print2term("----------------\n");
+    }
+
+    /* Read Maximum Creation Index (number of elements in group) */
+    if(flags & MAX_CREATE_PRESENT_BIT)
+    {
+        uint16_t max_create_index = readField(2, &pos);
+        if(verbose)
+        {
+            print2term("Maximum Creation Index:                                          %u\n", (unsigned short)max_create_index);
+        }
+    }
+
+    /* Read Heap and Name Offsets */
+    uint64_t heap_address = readField(metaData.offsetsize, &pos);
+    uint64_t name_index = readField(metaData.offsetsize, &pos);
+    if(verbose)
+    {
+        print2term("Heap Address:                                                    %lX\n", (unsigned long)heap_address);
+        print2term("Name Index:                                                      %lX\n", (unsigned long)name_index);
+    }
+
+    if(flags & CREATE_ORDER_PRESENT_BIT)
+    {
+        uint64_t create_order_index = readField(metaData.offsetsize, &pos);
+        if(verbose)
+        {
+            print2term("Creation Order Index:                                            %lX\n", (unsigned long)create_order_index);
+        }
+    }
+
+    /* Follow Heap Address if Provided */
+    if((int)heap_address != -1)
+    {
+        readFractalHeap(ATTRIBUTE_MSG, heap_address, hdr_flags, dlvl);
+    }
 
     /* Return Bytes Read */
     uint64_t ending_position = pos;

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -2912,6 +2912,10 @@ int H5FileBuffer::readHeaderContMsg (uint64_t pos, uint8_t hdr_flags, int dlvl)
                 throw RunTimeException(CRITICAL, RTE_ERROR, "invalid header continuation signature: 0x%llX", (unsigned long long)signature);
             }
         }
+        else
+        {
+            pos += 4;
+        }
 
         /* Read Continuation Header Messages */
         uint64_t end_of_chdr = hc_offset + hc_length - 4; // leave 4 bytes for checksum below

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -2008,11 +2008,11 @@ int H5FileBuffer::readDataspaceMsg (uint64_t pos, uint8_t hdr_flags, int dlvl)
     uint8_t version         = (uint8_t)readField(1, &pos);
     uint8_t dimensionality  = (uint8_t)readField(1, &pos);
     uint8_t flags           = (uint8_t)readField(1, &pos);
-    pos += 5; // go past reserved bytes
+    pos += version == 1 ? 5 : 1; // go past reserved bytes
 
     if(errorChecking)
     {
-        if(version != 1)
+        if(version != 1 && version != 2)
         {
             throw RunTimeException(CRITICAL, RTE_ERROR, "invalid dataspace version: %d", (int)version);
         }

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -498,7 +498,7 @@ void H5FileBuffer::ioRequest (uint64_t* pos, int64_t size, uint8_t* buffer, int6
              *  incur an additional mutex lock, whereas here it only occurs an aditional
              *  time when data isn't being cached (which is rare)
              */
-            ioContext->mut.unlock();
+            ioContext->mut.lock();
             {
                 ioContext->bytes_read += entry.size;
             }

--- a/packages/h5/H5Coro.h
+++ b/packages/h5/H5Coro.h
@@ -232,7 +232,8 @@ class H5FileBuffer
             FILTER_MSG              = 0xB,
             ATTRIBUTE_MSG           = 0xC,
             HEADER_CONT_MSG         = 0x10,
-            SYMBOL_TABLE_MSG        = 0x11
+            SYMBOL_TABLE_MSG        = 0x11,
+            ATTRIBUTE_INFO_MSG      = 0x15
         } msg_type_t;
 
         typedef enum {
@@ -322,51 +323,52 @@ class H5FileBuffer
         * Methods
         *--------------------------------------------------------------------*/
 
-        void                tearDown            (void);
+        void                tearDown              (void);
 
-        void                ioRequest           (uint64_t* pos, int64_t size, uint8_t* buffer, int64_t hint, bool cache);
-        bool                ioCheckCache        (uint64_t pos, int64_t size, cache_t* cache, uint64_t line_mask, cache_entry_t* entry);
-        static uint64_t     ioHashL1            (uint64_t key);
-        static uint64_t     ioHashL2            (uint64_t key);
+        void                ioRequest             (uint64_t* pos, int64_t size, uint8_t* buffer, int64_t hint, bool cache);
+        bool                ioCheckCache          (uint64_t pos, int64_t size, cache_t* cache, uint64_t line_mask, cache_entry_t* entry);
+        static uint64_t     ioHashL1              (uint64_t key);
+        static uint64_t     ioHashL2              (uint64_t key);
 
-        void                readByteArray       (uint8_t* data, int64_t size, uint64_t* pos);
-        uint64_t            readField           (int64_t size, uint64_t* pos);
-        void                readDataset         (info_t* info);
+        void                readByteArray         (uint8_t* data, int64_t size, uint64_t* pos);
+        uint64_t            readField             (int64_t size, uint64_t* pos);
+        void                readDataset           (info_t* info);
 
-        uint64_t            readSuperblock      (void);
-        int                 readFractalHeap     (msg_type_t type, uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readDirectBlock     (heap_info_t* heap_info, int block_size, uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readIndirectBlock   (heap_info_t* heap_info, int block_size, uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readBTreeV1         (uint64_t pos, uint8_t* buffer, uint64_t buffer_size, uint64_t buffer_offset);
-        btree_node_t        readBTreeNodeV1     (int ndims, uint64_t* pos);
-        int                 readSymbolTable     (uint64_t pos, uint64_t heap_data_addr, int dlvl);
+        uint64_t            readSuperblock        (void);
+        int                 readFractalHeap       (msg_type_t type, uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readDirectBlock       (heap_info_t* heap_info, int block_size, uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readIndirectBlock     (heap_info_t* heap_info, int block_size, uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readBTreeV1           (uint64_t pos, uint8_t* buffer, uint64_t buffer_size, uint64_t buffer_offset);
+        btree_node_t        readBTreeNodeV1       (int ndims, uint64_t* pos);
+        int                 readSymbolTable       (uint64_t pos, uint64_t heap_data_addr, int dlvl);
 
-        int                 readObjHdr          (uint64_t pos, int dlvl);
-        int                 readMessages        (uint64_t pos, uint64_t end, uint8_t hdr_flags, int dlvl);
-        int                 readObjHdrV1        (uint64_t pos, int dlvl);
-        int                 readMessagesV1      (uint64_t pos, uint64_t end, uint8_t hdr_flags, int dlvl);
-        int                 readMessage         (msg_type_t type, uint64_t size, uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readObjHdr            (uint64_t pos, int dlvl);
+        int                 readMessages          (uint64_t pos, uint64_t end, uint8_t hdr_flags, int dlvl);
+        int                 readObjHdrV1          (uint64_t pos, int dlvl);
+        int                 readMessagesV1        (uint64_t pos, uint64_t end, uint8_t hdr_flags, int dlvl);
+        int                 readMessage           (msg_type_t type, uint64_t size, uint64_t pos, uint8_t hdr_flags, int dlvl);
 
-        int                 readDataspaceMsg    (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readLinkInfoMsg     (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readDatatypeMsg     (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readFillValueMsg    (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readLinkMsg         (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readDataLayoutMsg   (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readFilterMsg       (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readAttributeMsg    (uint64_t pos, uint8_t hdr_flags, int dlvl, uint64_t size);
-        int                 readHeaderContMsg   (uint64_t pos, uint8_t hdr_flags, int dlvl);
-        int                 readSymbolTableMsg  (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readDataspaceMsg      (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readLinkInfoMsg       (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readDatatypeMsg       (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readFillValueMsg      (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readLinkMsg           (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readDataLayoutMsg     (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readFilterMsg         (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readAttributeMsg      (uint64_t pos, uint8_t hdr_flags, int dlvl, uint64_t size);
+        int                 readHeaderContMsg     (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readSymbolTableMsg    (uint64_t pos, uint8_t hdr_flags, int dlvl);
+        int                 readAttributeInfoMsg  (uint64_t pos, uint8_t hdr_flags, int dlvl);
 
-        void                parseDataset        (void);
-        const char*         type2str            (data_type_t datatype);
-        const char*         layout2str          (layout_t layout);
-        int                 highestBit          (uint64_t value);
-        int                 inflateChunk        (uint8_t* input, uint32_t input_size, uint8_t* output, uint32_t output_size);
-        int                 shuffleChunk        (uint8_t* input, uint32_t input_size, uint8_t* output, uint32_t output_offset, uint32_t output_size, int type_size);
+        void                parseDataset          (void);
+        const char*         type2str              (data_type_t datatype);
+        const char*         layout2str            (layout_t layout);
+        int                 highestBit            (uint64_t value);
+        int                 inflateChunk          (uint8_t* input, uint32_t input_size, uint8_t* output, uint32_t output_size);
+        int                 shuffleChunk          (uint8_t* input, uint32_t input_size, uint8_t* output, uint32_t output_offset, uint32_t output_size, int type_size);
 
-        static uint64_t     metaGetKey          (const char* url);
-        static void         metaGetUrl          (char* url, const char* resource, const char* dataset);
+        static uint64_t     metaGetKey            (const char* url);
+        static void         metaGetUrl            (char* url, const char* resource, const char* dataset);
 
         /*--------------------------------------------------------------------
         * Data


### PR DESCRIPTION
* Support DataSpaceMsg version 2
* Support Attribute Info message version 0
* Fix bug where position was not moved when reading without error-checking enabled
* Fix bug where mutex was unlocked instead of locked when requested data was found in cache