### PR TITLE
Raster cache update. 

### DIFF
--- a/packages/geo/GeoRaster.cpp
+++ b/packages/geo/GeoRaster.cpp
@@ -1160,31 +1160,14 @@ void GeoRaster::updateCache(OGRPoint& p)
         }
     }
 
-#if 1
     /* Maintain cache from getting too big */
     while(rasterDict.length() > MAX_CACHED_RASTERS)
     {
         uint32_t removedRasters = removeOldestRasterGroup();
         if(removedRasters == 0) break;
     }
-#else
-    /* Maintain cache from getting too big */
-    key = rasterDict.first(&raster);
-    while(key != NULL)
-    {
-        if(rasterDict.length() <= MAX_CACHED_RASTERS)
-            break;
-
-        assert(raster);
-        if(!raster->enabled)
-        {
-            rasterDict.remove(key);
-            delete raster;
-        }
-        key = rasterDict.next(&raster);
-    }
-#endif
 }
+
 
 /*----------------------------------------------------------------------------
  * filterRasters

--- a/packages/geo/GeoRaster.h
+++ b/packages/geo/GeoRaster.h
@@ -194,6 +194,7 @@ class GeoRaster: public LuaObject
             uint32_t        radiusInPixels;
 
             double          gpsTime;
+            double          useTime;
 
             /* Last sample information */
             OGRPoint        point;
@@ -314,6 +315,7 @@ class GeoRaster: public LuaObject
         void       readPixel               (Raster* raster);
         void       resamplePixel           (Raster* raster);
         void       computeZonalStats       (Raster* raster);
+        uint32_t   removeOldestRasterGroup (void);
 
 };
 


### PR DESCRIPTION
"Oldest" raster group stored in cache is removed first when cache needs to be trimmed. There is a very minor performance penalty but removing oldest rasters is very desirable. The size of cache is still 50 rasters. Notice that the cache can grow above this value. 50 is the max number of cached rasters not currently in use.