### PR TITLE
Use found READLINE_LIB; typo in bindings-python/init.cpp

### DIFF
--- a/packages/core/CMakeLists.txt
+++ b/packages/core/CMakeLists.txt
@@ -11,7 +11,7 @@ if (LUA_FOUND AND READLINE_LIB)
     target_link_libraries (slideruleLib PUBLIC ${LUA_LIBRARIES})
     target_include_directories (slideruleLib PUBLIC ${LUA_INCLUDE_DIR})
 
-    target_link_libraries (slideruleLib PUBLIC readline)
+    target_link_libraries (slideruleLib PUBLIC ${READLINE_LIB})
 
     target_sources (slideruleLib
         PRIVATE

--- a/targets/binding-python/init.cpp
+++ b/targets/binding-python/init.cpp
@@ -43,7 +43,7 @@
 #include "ccsds.h"
 #endif
 
-#ifdef __h5__
+#ifdef __geo__
 #include "geo.h"
 #endif
 


### PR DESCRIPTION
Link against whatever `find_library (READLINE_LIB readline)` finds. Otherwise, if `readline` is in a nonstandard location (e.g., installed from conda) then building will fail.

EDIT: Also, this resolves what looks like a typo in `targets/bindings-python/init.cpp`.