### PR TITLE
sliderule: update to EPSG:7912, use 3D Point geometry

### DIFF
--- a/clients/python/sliderule/gedi.py
+++ b/clients/python/sliderule/gedi.py
@@ -62,7 +62,7 @@ ALL_BEAMS = -1
 #
 # Flatten Batches
 #
-def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array, height_keys):
+def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array, height_key):
 
     # Latch Start Time
     tstart_flatten = time.perf_counter()
@@ -135,7 +135,7 @@ def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array,
         logger.debug("No response returned")
 
     # Build Initial GeoDataFrame
-    gdf = sliderule.todataframe(columns, height_keys=height_keys)
+    gdf = sliderule.todataframe(columns, height_key=height_key)
 
     # Merge Ancillary Fields
     tstart_merge = time.perf_counter()
@@ -202,7 +202,7 @@ def __query_resources(parm, dataset, **kwargs):
 #
 #  Perform Processing Request
 #
-def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, dataset, api, rec, height_keys, profile):
+def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, dataset, api, rec, height_key, profile):
     try:
         tstart = time.perf_counter()
 
@@ -221,7 +221,7 @@ def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_ar
         rsps = sliderule.source(api, rqst, stream=True, callbacks=callbacks)
 
         # Flatten Responses
-        gdf = __flattenbatches(rsps, rec, 'footprint', parm, keep_id, as_numpy_array, height_keys)
+        gdf = __flattenbatches(rsps, rec, 'footprint', parm, keep_id, as_numpy_array, height_key)
 
         # Return Response
         profiles[profile] = time.perf_counter() - tstart
@@ -277,7 +277,7 @@ def gedi04a (parm, resource, asset=DEFAULT_L4A_ASSET):
 #
 #  Parallel GEDI04A
 #
-def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation']):
+def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_key=None):
     '''
     Performs subsetting in parallel on GEDI data and returns elevation footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -297,8 +297,8 @@ def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -319,7 +319,7 @@ def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "ornldaac-s3"
         >>> rsps = gedi.gedi04ap(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI_L4A_AGB_Density_V2_1_2056', 'gedi04ap', 'gedi04arec', height_keys, gedi04ap.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI_L4A_AGB_Density_V2_1_2056', 'gedi04ap', 'gedi04arec', height_key, gedi04ap.__name__)
 
 #
 #  GEDI L2A
@@ -347,7 +347,7 @@ def gedi02a (parm, resource, asset=DEFAULT_L2A_ASSET):
 #
 #  Parallel GEDI02A
 #
-def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation_lm', 'elevation_hr']):
+def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_key=None):
     '''
     Performs subsetting in parallel on GEDI data and returns geolocated footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -367,8 +367,8 @@ def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -389,7 +389,7 @@ def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "gedi-local"
         >>> rsps = gedi.gedi02ap(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI02_A', 'gedi02ap', 'gedi02arec', height_keys, gedi02ap.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI02_A', 'gedi02ap', 'gedi02arec', height_key, gedi02ap.__name__)
 
 #
 #  GEDI L1B
@@ -417,7 +417,7 @@ def gedi01b (parm, resource, asset=DEFAULT_L1B_ASSET):
 #
 #  Parallel GEDI01B
 #
-def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation_start', 'elevation_stop']):
+def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_key=None):
     '''
     Performs subsetting in parallel on GEDI data and returns geolocated footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -437,8 +437,8 @@ def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -459,4 +459,4 @@ def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "gedi-local"
         >>> rsps = gedi.gedi01bp(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI01_B', 'gedi01bp', 'gedi01brec', height_keys, gedi01bp.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI01_B', 'gedi01bp', 'gedi01brec', height_key, gedi01bp.__name__)

--- a/clients/python/sliderule/gedi.py
+++ b/clients/python/sliderule/gedi.py
@@ -62,7 +62,7 @@ ALL_BEAMS = -1
 #
 # Flatten Batches
 #
-def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array):
+def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array, height_keys):
 
     # Latch Start Time
     tstart_flatten = time.perf_counter()
@@ -135,7 +135,7 @@ def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array)
         logger.debug("No response returned")
 
     # Build Initial GeoDataFrame
-    gdf = sliderule.todataframe(columns)
+    gdf = sliderule.todataframe(columns, height_keys=height_keys)
 
     # Merge Ancillary Fields
     tstart_merge = time.perf_counter()
@@ -202,7 +202,7 @@ def __query_resources(parm, dataset, **kwargs):
 #
 #  Perform Processing Request
 #
-def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, dataset, api, rec, profile):
+def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, dataset, api, rec, height_keys, profile):
     try:
         tstart = time.perf_counter()
 
@@ -221,7 +221,7 @@ def __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_ar
         rsps = sliderule.source(api, rqst, stream=True, callbacks=callbacks)
 
         # Flatten Responses
-        gdf = __flattenbatches(rsps, rec, 'footprint', parm, keep_id, as_numpy_array)
+        gdf = __flattenbatches(rsps, rec, 'footprint', parm, keep_id, as_numpy_array, height_keys)
 
         # Return Response
         profiles[profile] = time.perf_counter() - tstart
@@ -277,7 +277,7 @@ def gedi04a (parm, resource, asset=DEFAULT_L4A_ASSET):
 #
 #  Parallel GEDI04A
 #
-def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False):
+def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation']):
     '''
     Performs subsetting in parallel on GEDI data and returns elevation footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -297,6 +297,8 @@ def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
+        height_keys:    list
+                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
 
     Returns
     -------
@@ -317,7 +319,7 @@ def gedi04ap(parm, asset=DEFAULT_L4A_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "ornldaac-s3"
         >>> rsps = gedi.gedi04ap(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI_L4A_AGB_Density_V2_1_2056', 'gedi04ap', 'gedi04arec', gedi04ap.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI_L4A_AGB_Density_V2_1_2056', 'gedi04ap', 'gedi04arec', height_keys, gedi04ap.__name__)
 
 #
 #  GEDI L2A
@@ -345,7 +347,7 @@ def gedi02a (parm, resource, asset=DEFAULT_L2A_ASSET):
 #
 #  Parallel GEDI02A
 #
-def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False):
+def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation_lm', 'elevation_hr']):
     '''
     Performs subsetting in parallel on GEDI data and returns geolocated footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -365,6 +367,8 @@ def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
+        height_keys:    list
+                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
 
     Returns
     -------
@@ -385,7 +389,7 @@ def gedi02ap(parm, asset=DEFAULT_L2A_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "gedi-local"
         >>> rsps = gedi.gedi02ap(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI02_A', 'gedi02ap', 'gedi02arec', gedi02ap.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI02_A', 'gedi02ap', 'gedi02arec', height_keys, gedi02ap.__name__)
 
 #
 #  GEDI L1B
@@ -413,7 +417,7 @@ def gedi01b (parm, resource, asset=DEFAULT_L1B_ASSET):
 #
 #  Parallel GEDI01B
 #
-def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False):
+def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['elevation_start', 'elevation_stop']):
     '''
     Performs subsetting in parallel on GEDI data and returns geolocated footprints.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -433,6 +437,8 @@ def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_i
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
+        height_keys:    list
+                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
 
     Returns
     -------
@@ -453,4 +459,4 @@ def gedi01bp(parm, asset=DEFAULT_L1B_ASSET, callbacks={}, resources=None, keep_i
         >>> asset = "gedi-local"
         >>> rsps = gedi.gedi01bp(parms, asset=asset, resources=resources)
     '''
-    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI01_B', 'gedi01bp', 'gedi01brec', gedi01bp.__name__)
+    return __processing_request(parm, asset, callbacks, resources, keep_id, as_numpy_array, 'GEDI01_B', 'gedi01bp', 'gedi01brec', height_keys, gedi01bp.__name__)

--- a/clients/python/sliderule/icesat2.py
+++ b/clients/python/sliderule/icesat2.py
@@ -139,7 +139,7 @@ def __calcspot(sc_orient, track, pair):
 #
 # Flatten Batches
 #
-def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array, height_keys):
+def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array, height_key):
 
     # Latch Start Time
     tstart_flatten = time.perf_counter()
@@ -239,7 +239,7 @@ def __flattenbatches(rsps, rectype, batch_column, parm, keep_id, as_numpy_array,
         logger.debug("No response returned")
 
     # Build Initial GeoDataFrame
-    gdf = sliderule.todataframe(columns, lon_key='lon', lat_key='lat', height_keys=height_keys)
+    gdf = sliderule.todataframe(columns, lon_key='lon', lat_key='lat', height_key=height_key)
 
     # Merge Ancillary Fields
     tstart_merge = time.perf_counter()
@@ -372,7 +372,7 @@ def atl06 (parm, resource, asset=DEFAULT_ASSET):
 #
 #  Parallel ATL06
 #
-def atl06p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['h_mean']):
+def atl06p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_key=None):
     '''
     Performs ATL06-SR processing in parallel on ATL03 data and returns geolocated elevations.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -401,8 +401,8 @@ def atl06p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callb
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -451,7 +451,7 @@ def atl06p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callb
         rsps = sliderule.source("atl06p", rqst, stream=True, callbacks=callbacks)
 
         # Flatten Responses
-        gdf = __flattenbatches(rsps, 'atl06rec', 'elevation', parm, keep_id, as_numpy_array, height_keys)
+        gdf = __flattenbatches(rsps, 'atl06rec', 'elevation', parm, keep_id, as_numpy_array, height_key)
 
         # Return Response
         profiles[atl06p.__name__] = time.perf_counter() - tstart
@@ -488,7 +488,7 @@ def atl03s (parm, resource, asset=DEFAULT_ASSET):
 #
 #  Parallel Subsetted ATL03
 #
-def atl03sp(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, height_keys=['height']):
+def atl03sp(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, height_key=None):
     '''
     Performs ATL03 subsetting in parallel on ATL03 data and returns photon segment data.  Unlike the `atl03s <#atl03s>`_ function,
     this function does not take a resource as a parameter; instead it is expected that the **parm** argument includes a polygon which
@@ -514,8 +514,8 @@ def atl03sp(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, call
                         a list of granules to process (e.g. ["ATL03_20181019065445_03150111_005_01.h5", ...])
         keep_id:        bool
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -652,7 +652,7 @@ def atl03sp(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, call
                     profiles["flatten"] = time.perf_counter() - tstart_flatten
 
                     # Create DataFrame
-                    gdf = sliderule.todataframe(columns, lat_key="latitude", lon_key="longitude", height_keys=height_keys)
+                    gdf = sliderule.todataframe(columns, lat_key="latitude", lon_key="longitude", height_key=height_key)
 
                     # Calculate Spot Column
                     gdf['spot'] = gdf.apply(lambda row: __calcspot(row["sc_orient"], row["track"], row["pair"]), axis=1)
@@ -698,7 +698,7 @@ def atl08 (parm, resource, asset=DEFAULT_ASSET):
 #
 #  Parallel ATL08
 #
-def atl08p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_keys=['h_te_median', 'h_max_canopy', 'h_min_canopy', 'h_mean_canopy', 'h_canopy']):
+def atl08p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callbacks={}, resources=None, keep_id=False, as_numpy_array=False, height_key=None):
     '''
     Performs ATL08-PhoREAL processing in parallel on ATL03 and ATL08 data and returns geolocated vegatation statistics.  This function expects that the **parm** argument
     includes a polygon which is used to fetch all available resources from the CMR system automatically.  If **resources** is specified
@@ -727,8 +727,8 @@ def atl08p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callb
                         whether to retain the "extent_id" column in the GeoDataFrame for future merges
         as_numpy_array: bool
                         whether to provide all sampled values as numpy arrays even if there is only a single value
-        height_keys:    list
-                        list of strings identifying the name of the columns to try in the order provided for the 3D CRS transformation
+        height_key:     str
+                        identifies the name of the column provided for the 3D CRS transformation
 
     Returns
     -------
@@ -753,7 +753,7 @@ def atl08p(parm, asset=DEFAULT_ASSET, version=DEFAULT_ICESAT2_SDP_VERSION, callb
         rsps = sliderule.source("atl08p", rqst, stream=True, callbacks=callbacks)
 
         # Flatten Responses
-        gdf = __flattenbatches(rsps, 'atl08rec', 'vegetation', parm, keep_id, as_numpy_array, height_keys)
+        gdf = __flattenbatches(rsps, 'atl08rec', 'vegetation', parm, keep_id, as_numpy_array, height_key)
 
         # Return Response
         profiles[atl08p.__name__] = time.perf_counter() - tstart

--- a/clients/python/sliderule/sliderule.py
+++ b/clients/python/sliderule/sliderule.py
@@ -549,7 +549,7 @@ def getvalues(data, dtype, size):
 #
 #  Dictionary to GeoDataFrame
 #
-def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude", height_keys=[], **kwargs):
+def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude", height_key=None, **kwargs):
 
     # Latch Start Time
     tstart = time.perf_counter()
@@ -568,15 +568,10 @@ def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude
     # Generate Geometry Column
     # 3D point geometry
     # This enables 3D CRS transformations using the to_crs() method
-    height_key = None
-    for k in height_keys:
-        if k in columns:
-            height_key = k
-            break
-    if height_key != None:
-        geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key], columns[height_key])
-    else:
+    if height_key == None:
         geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key])
+    else:
+        geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key], columns[height_key])
     del columns[lon_key]
     del columns[lat_key]
 

--- a/clients/python/sliderule/sliderule.py
+++ b/clients/python/sliderule/sliderule.py
@@ -51,11 +51,8 @@ from sliderule import version
 # Coordinate system on the surface of a sphere or ellipsoid of reference.
 EPSG_WGS84 = "EPSG:4326"
 
-#Output CRS for SlideRule GeoDataFrame
-#SLIDERULE_EPSG = EPSG_WGS84
-
-#This is 3D CRS for ITRF2014 realization with 2010.0 epoch: https://epsg.io/7912
-#Note: using GRS80 ellipsoid, negligible difference in inverse flattening from WGS84
+# This is 3D CRS for ITRF2014 realization with 2010.0 epoch: https://epsg.io/7912
+# Note: using GRS80 ellipsoid, negligible difference in inverse flattening from WGS84
 SLIDERULE_EPSG = "EPSG:7912"
 
 PUBLIC_URL = "slideruleearth.io"
@@ -552,7 +549,7 @@ def getvalues(data, dtype, size):
 #
 #  Dictionary to GeoDataFrame
 #
-def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude", height_key="h_mean", **kwargs):
+def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude", height_keys=[], **kwargs):
 
     # Latch Start Time
     tstart = time.perf_counter()
@@ -569,11 +566,17 @@ def todataframe(columns, time_key="time", lon_key="longitude", lat_key="latitude
     columns['time'] = columns[time_key].astype('datetime64[ns]')
 
     # Generate Geometry Column
-    #2D point geometry
-    #geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key])
-    #3D point geometry
-    #This enables 3D CRS transformations using the to_crs() method
-    geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key], columns[height_key])
+    # 3D point geometry
+    # This enables 3D CRS transformations using the to_crs() method
+    height_key = None
+    for k in height_keys:
+        if k in columns:
+            height_key = k
+            break
+    if height_key != None:
+        geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key], columns[height_key])
+    else:
+        geometry = geopandas.points_from_xy(columns[lon_key], columns[lat_key])
     del columns[lon_key]
     del columns[lat_key]
 

--- a/clients/python/tests/test_3dcrs.py
+++ b/clients/python/tests/test_3dcrs.py
@@ -1,0 +1,65 @@
+"""Tests for sliderule icesat2 atl06-sr algorithm."""
+
+import pytest
+from sliderule import icesat2
+
+@pytest.mark.network
+class Test3dCRS:
+    def test_atl06p(self, domain, asset, organization, desired_nodes):
+        icesat2.init(domain, organization=organization, desired_nodes=desired_nodes, bypass_dns=True)
+        resource = "ATL03_20181019065445_03150111_005_01.h5"
+        parms = { "cnf": "atl03_high",
+                  "ats": 20.0,
+                  "cnt": 10,
+                  "len": 40.0,
+                  "res": 20.0,
+                  "maxi": 1 }
+        gdf = icesat2.atl06p(parms, asset, resources=[resource], height_key='h_mean')
+        assert min(gdf["rgt"]) == 315
+        assert min(gdf["cycle"]) == 1
+        assert len(gdf["h_mean"]) == 622419
+
+    def test_atl03sp(self, domain, asset, organization, desired_nodes):
+        icesat2.init(domain, organization=organization, desired_nodes=desired_nodes, bypass_dns=True)
+        resource = "ATL03_20181019065445_03150111_005_01.h5"
+        region = [ { "lat": -80.75, "lon": -70.00 },
+                   { "lat": -81.00, "lon": -70.00 },
+                   { "lat": -81.00, "lon": -65.00 },
+                   { "lat": -80.75, "lon": -65.00 },
+                   { "lat": -80.75, "lon": -70.00 } ]
+        parms = { "poly": region,
+                  "track": 1,
+                  "cnf": 0,
+                  "pass_invalid": True,
+                  "yapc": { "score": 0 },
+                  "atl08_class": ["atl08_noise", "atl08_ground", "atl08_canopy", "atl08_top_of_canopy", "atl08_unclassified"],
+                  "ats": 10.0,
+                  "cnt": 5,
+                  "len": 20.0,
+                  "res": 20.0,
+                  "maxi": 1 }
+        gdf = icesat2.atl03sp(parms, asset, resources=[resource], height_key='height')
+        assert min(gdf["rgt"]) == 315
+        assert min(gdf["cycle"]) == 1
+        assert len(gdf["height"]) == 488690
+
+    def test_atl08p(self, domain, asset, organization, desired_nodes):
+        icesat2.init(domain, organization=organization, desired_nodes=desired_nodes, bypass_dns=True)
+        resource = "ATL03_20181213075606_11560106_005_01.h5"
+        region = [ {"lon": -108.3435200747503, "lat": 38.89102961045247},
+                   {"lon": -107.7677425431139, "lat": 38.90611184543033},
+                   {"lon": -107.7818591266989, "lat": 39.26613714985466},
+                   {"lon": -108.3605610678553, "lat": 39.25086131372244},
+                   {"lon": -108.3435200747503, "lat": 38.89102961045247} ]
+        parms = {
+            "poly": region,
+            "srt": icesat2.SRT_LAND,
+            "len": 100,
+            "res": 100,
+            "pass_invalid": True, 
+            "atl08_class": ["atl08_ground", "atl08_canopy", "atl08_top_of_canopy"],
+            "phoreal": {"binsize": 1.0, "geoloc": "center", "use_abs_h": False, "send_waveform": True} 
+        }
+        gdf = icesat2.atl08p(parms, asset=asset, resources=[resource], height_key='h_te_median')
+        assert len(gdf) > 0
+


### PR DESCRIPTION
Addresses some of the issues in https://github.com/ICESat2-SlideRule/sliderule/issues/198

After some experimentation with latest PROJ (9.2.1) and GeoPandas, it appears that if we include 3D Point Geometries, we can do the 3D CRS transformations using the `to_crs()` functionality, since we now assign EPSG:7912 (3D CRS for ITRF2014 realization).

This PR updates the default CRS for the Python client output (was inconsistent with what is returned by the server-side GeoRaster code).  Also updated a few comments (EPSG:4326 is not MERCATOR), and fixed a typo.

There may be some unforeseen gotchas with the 3D Points, and we are preserving a redundant copy of the `h_mean` attribute as the Z coordinate in the Point, but I think this is acceptable. We don't want to drop the `h_mean` column.  An alternative would be to allow the user to specify whether they want a 2D or 3D Point geometry column for the GeoDataFrame.