### PR TITLE
Georaster jp

### DIFF
--- a/clients/python/sliderule/raster.py
+++ b/clients/python/sliderule/raster.py
@@ -40,6 +40,19 @@ logger = logging.getLogger(__name__)
 profiles = {}
 
 ###############################################################################
+# UTILITIES
+###############################################################################
+
+#
+# poly2bbox
+#
+def poly2bbox(poly):
+    lats = [p["lat"] for p in poly]
+    lons = [p["lon"] for p in poly]
+    bbox = [ min(lons), min(lats), max(lons), max(lats) ]
+    return bbox
+
+###############################################################################
 # APIs
 ###############################################################################
 
@@ -63,7 +76,7 @@ def sample(asset, coordinates, parms={}):
     -------
     GeoDataFrame
         geolocated sampled values along with metadata
-    
+
     Examples
     --------
         >>> import sliderule
@@ -72,15 +85,15 @@ def sample(asset, coordinates, parms={}):
     # Massage Arguments
     if type(coordinates[0]) != list:
         coorindates = [coorindates]
-    
+
     # Perform Request
     rqst = {"samples": {"asset": asset, **parms}, "coordinates": coordinates}
     rsps = sliderule.source("samples", rqst)
-    
+
     # Sanity Check Response
     if len(rsps) <= 0:
         return sliderule.emptyframe()
-    
+
     # Count Records
     num_records = 0
     for input_coord_response in rsps["samples"]:
@@ -100,26 +113,26 @@ def sample(asset, coordinates, parms={}):
 
     # Build Initial Columns
     columns = {
-        'time': numpy.empty(num_records, numpy.int64), 
-        'latitude': numpy.empty(num_records, numpy.double), 
-        'longitude': numpy.empty(num_records, numpy.double), 
-        'file': [], 
+        'time': numpy.empty(num_records, numpy.int64),
+        'latitude': numpy.empty(num_records, numpy.double),
+        'longitude': numpy.empty(num_records, numpy.double),
+        'file': [],
         'value': numpy.empty(num_records, value_nptype)
     }
     if 'with_flags' in parms:
         columns = {
-            'flags': numpy.empty(num_records, flags_nptype), 
+            'flags': numpy.empty(num_records, flags_nptype),
             **columns
         }
     if 'zonal_stats' in parms:
         columns = {
-            'count': numpy.empty(num_records, count_nptype), 
-            'min': numpy.empty(num_records, min_nptype), 
-            'max': numpy.empty(num_records, max_nptype), 
-            'mean': numpy.empty(num_records, mean_nptype), 
-            'median': numpy.empty(num_records, median_nptype), 
-            'stdev': numpy.empty(num_records, stdev_nptype), 
-            'mad': numpy.empty(num_records, mad_nptype), 
+            'count': numpy.empty(num_records, count_nptype),
+            'min': numpy.empty(num_records, min_nptype),
+            'max': numpy.empty(num_records, max_nptype),
+            'mean': numpy.empty(num_records, mean_nptype),
+            'median': numpy.empty(num_records, median_nptype),
+            'stdev': numpy.empty(num_records, stdev_nptype),
+            'mad': numpy.empty(num_records, mad_nptype),
             **columns
         }
 

--- a/packages/geo/GdalRaster.cpp
+++ b/packages/geo/GdalRaster.cpp
@@ -63,7 +63,6 @@ GdalRaster::GdalRaster(GeoParms* _parms, const std::string& _fileName, double _g
    sample     (),
    transf     (NULL),
    overrideCRS(cb),
-   aoi        (),
    fileName   (_fileName),
    dset       (NULL),
    band       (NULL),
@@ -612,14 +611,15 @@ void GdalRaster::createTransform(void)
     }
 
     /* Limit to area of interest if AOI was set */
+    bbox_t* aoi = &parms->aoi_bbox;
     bbox_t empty = {0, 0, 0, 0};
-    if(memcmp(&aoi, &empty, sizeof(bbox_t)))
+    if(memcmp(aoi, &empty, sizeof(bbox_t)))
     {
-        if(!options.SetAreaOfInterest(aoi.lon_min, aoi.lat_min, aoi.lon_max, aoi.lat_max))
+        if(!options.SetAreaOfInterest(aoi->lon_min, aoi->lat_min, aoi->lon_max, aoi->lat_max))
             throw RunTimeException(CRITICAL, RTE_ERROR, "Failed to set AOI");
 
         mlog(DEBUG, "Limited AOI to: lon/lat Min (%.2lf, %.2lf), lon/lat Max (%.2lf, %.2lf)",
-             aoi.lon_min, aoi.lat_min, aoi.lon_max, aoi.lat_max);
+             aoi->lon_min, aoi->lat_min, aoi->lon_max, aoi->lat_max);
     }
 
     /* Force traditional axis order (lon, lat) */

--- a/packages/geo/GdalRaster.h
+++ b/packages/geo/GdalRaster.h
@@ -112,13 +112,8 @@ class GdalRaster
             double z;
         };
 
-
-        typedef struct {
-            double lon_min;
-            double lat_min;
-            double lon_max;
-            double lat_max;
-        } bbox_t;
+        /* import bbox_t into this namespace from GeoParms.h */
+        using bbox_t=GeoParms::bbox_t;
 
         /*--------------------------------------------------------------------
          * Methods

--- a/packages/geo/GdalRaster.h
+++ b/packages/geo/GdalRaster.h
@@ -124,8 +124,6 @@ class GdalRaster
         void               open           (void);
         void               setPOI         (const Point& _poi);
         void               samplePOI      (void);
-        void               setAOI         (const bbox_t& _aoi) { aoi = _aoi; }
-        const bbox_t&      getAOI         (void) { return aoi; }
         void               setFileName    (const std::string& _fileName ) { fileName = _fileName; }
         const std::string& getFileName    (void) { return fileName;}
         RasterSample&      getSample      (void) { return sample; }
@@ -166,7 +164,6 @@ class GdalRaster
         OGRSpatialReference sourceCRS;
         OGRSpatialReference targetCRS;
         overrideCRS_t       overrideCRS;
-        bbox_t              aoi;
 
         std::string     fileName;
         GDALDataset    *dset;

--- a/packages/geo/GeoIndexedRaster.cpp
+++ b/packages/geo/GeoIndexedRaster.cpp
@@ -575,14 +575,14 @@ uint32_t GeoIndexedRaster::updateCache(GdalRaster::Point& poi)
             bool inCache = cache.find(key, &item);
             if(!inCache)
             {
+                /* Limit area of interest to the extent of vector index file */
+                parms->aoi_bbox = bbox;
+
                 /* Create new cache item with raster */
                 item = new cacheitem_t();
                 item->raster = new GdalRaster(parms, rinfo.fileName,
                                               static_cast<double>(rgroup->gpsTime / 1000),
                                               rinfo.dataIsElevation, crscb);
-
-                /* Set area of interest from index file extent */
-                item->raster->setAOI(bbox);
             }
 
             item->raster->setPOI(poi);

--- a/packages/geo/GeoParms.cpp
+++ b/packages/geo/GeoParms.cpp
@@ -392,7 +392,7 @@ void GeoParms::getAoiBbox (lua_State* L, int index, bool* provided)
     /* Must be table of coordinates */
     if(!lua_istable(L, index))
     {
-        mlog(ERROR, "bounding box must be upplied as a table");
+        mlog(DEBUG, "bounding box must be supplied as a table");
         return;
     }
 

--- a/packages/geo/GeoParms.cpp
+++ b/packages/geo/GeoParms.cpp
@@ -53,6 +53,7 @@ const char* GeoParms::URL_SUBSTRING         = "substr";
 const char* GeoParms::CLOSEST_TIME          = "closest_time";
 const char* GeoParms::USE_POI_TIME          = "use_poi_time";
 const char* GeoParms::PROJ_PIPELINE         = "proj_pipeline";
+const char* GeoParms::AOI_BBOX              = "aoi_bbox";
 const char* GeoParms::CATALOG               = "catalog";
 const char* GeoParms::BANDS                 = "bands";
 const char* GeoParms::ASSET                 = "asset";
@@ -117,6 +118,7 @@ GeoParms::GeoParms (lua_State* L, int index, bool asset_required):
     filter_closest_time (false),
     use_poi_time        (false),
     proj_pipeline       (NULL),
+    aoi_bbox            {0, 0, 0, 0},
     catalog             (NULL),
     asset_name          (NULL),
     asset               (NULL),
@@ -235,6 +237,12 @@ GeoParms::GeoParms (lua_State* L, int index, bool asset_required):
             if(proj_pipeline) mlog(DEBUG, "Setting %s to %s", PROJ_PIPELINE, proj_pipeline);
             lua_pop(L, 1);
 
+            /* AOI BBOX */
+            lua_getfield(L, index, AOI_BBOX);
+            getAoiBbox(L, -1, &field_provided);
+            if(field_provided) mlog(CRITICAL, "Setting %s to [%.4lf, %.4lf, %.4lf, %.4lf]", AOI_BBOX, aoi_bbox.lon_min, aoi_bbox.lat_min, aoi_bbox.lon_max, aoi_bbox.lat_max);
+            lua_pop(L, 1);
+
             /* Catalog */
             lua_getfield(L, index, CATALOG);
             const char* catalog_str = LuaObject::getLuaString(L, -1, true, NULL);
@@ -310,6 +318,12 @@ void GeoParms::cleanup (void)
         asset->releaseLuaObject();
         asset = NULL;
     }
+
+    if(proj_pipeline)
+    {
+        delete [] proj_pipeline;
+        proj_pipeline = NULL;
+    }
 }
 
 /*----------------------------------------------------------------------------
@@ -365,6 +379,53 @@ void GeoParms::getLuaBands (lua_State* L, int index, bool* provided)
     {
         mlog(ERROR, "Bands must be provided as a table or string");
     }
+}
+
+/*----------------------------------------------------------------------------
+ * getAoiBbox - [min_lon, min_lat, max_lon, max_lat]
+ *----------------------------------------------------------------------------*/
+void GeoParms::getAoiBbox (lua_State* L, int index, bool* provided)
+{
+    /* Reset Provided */
+    *provided = false;
+
+    /* Must be table of coordinates */
+    if(!lua_istable(L, index))
+    {
+        mlog(ERROR, "bounding box must be upplied as a table");
+        return;
+    }
+
+    /* Get Number of Points in BBOX */
+    int num_points = lua_rawlen(L, index);
+    if(num_points != 4)
+    {
+        mlog(ERROR, "bounding box must be supplied as four points");
+        return;
+    }
+
+    /* Get Minimum Longitude */
+    lua_rawgeti(L, index, 1);
+    aoi_bbox.lon_min = LuaObject::getLuaFloat(L, -1);
+    lua_pop(L, 1);
+
+    /* Get Minimum Latitude */
+    lua_rawgeti(L, index, 2);
+    aoi_bbox.lat_min = LuaObject::getLuaFloat(L, -1);
+    lua_pop(L, 1);
+
+    /* Get Maximum Longitude */
+    lua_rawgeti(L, index, 3);
+    aoi_bbox.lon_max = LuaObject::getLuaFloat(L, -1);
+    lua_pop(L, 1);
+
+    /* Get Maximum Latitude */
+    lua_rawgeti(L, index, 4);
+    aoi_bbox.lat_max = LuaObject::getLuaFloat(L, -1);
+    lua_pop(L, 1);
+
+    /* Set Provided */
+    *provided = true;
 }
 
 /*----------------------------------------------------------------------------

--- a/packages/geo/GeoParms.h
+++ b/packages/geo/GeoParms.h
@@ -74,6 +74,7 @@ class GeoParms: public LuaObject
         static const char* CLOSEST_TIME;
         static const char* USE_POI_TIME;
         static const char* PROJ_PIPELINE;
+        static const char* AOI_BBOX;
         static const char* CATALOG;
         static const char* BANDS;
         static const char* ASSET;
@@ -99,6 +100,13 @@ class GeoParms: public LuaObject
 
         typedef MgList<const char*, 8, true> band_list_t;
 
+        typedef struct {
+            double lon_min;
+            double lat_min;
+            double lon_max;
+            double lat_max;
+        } bbox_t;
+
         /*--------------------------------------------------------------------
         * Data
         *--------------------------------------------------------------------*/
@@ -115,6 +123,7 @@ class GeoParms: public LuaObject
         TimeLib::gmt_time_t closest_time;
         bool                use_poi_time;
         const char*         proj_pipeline;
+        bbox_t              aoi_bbox;
         const char*         catalog;
         band_list_t         bands;
         const char*         asset_name;
@@ -138,6 +147,8 @@ class GeoParms: public LuaObject
         void                cleanup         (void);
         GDALRIOResampleAlg  str2algo        (const char* str);
         void                getLuaBands     (lua_State* L, int index, bool* provided);
+        void                getAoiBbox      (lua_State* L, int index, bool* provided);
+
         static int          luaAssetName    (lua_State* L);
         static int          luaAssetRegion  (lua_State* L);
         static int          luaSetKeySpace  (lua_State* L);

--- a/plugins/gedi/plugin/Gedi03Raster.h
+++ b/plugins/gedi/plugin/Gedi03Raster.h
@@ -55,8 +55,6 @@ class Gedi03Raster: public GeoRaster
         static RasterObject* create (lua_State* L, GeoParms* _parms)
         { return new Gedi03Raster(L, _parms); }
 
-        virtual ~Gedi03Raster (void) {}
-
     protected:
 
 
@@ -69,12 +67,6 @@ class Gedi03Raster: public GeoRaster
                  std::string(_parms->asset->getPath()).append("/").append(_parms->asset->getIndex()).c_str(),
                  TimeLib::datetime2gps(2022, 1, 19),
                  true /* Data is elevation */) {}
-
-        private:
-
-        /*--------------------------------------------------------------------
-         * Data
-         *--------------------------------------------------------------------*/
 };
 
 #endif  /* __gedi03_raster__ */

--- a/plugins/gedi/plugin/Gedi04bRaster.h
+++ b/plugins/gedi/plugin/Gedi04bRaster.h
@@ -55,10 +55,7 @@ class Gedi04bRaster: public GeoRaster
         static RasterObject* create (lua_State* L, GeoParms* _parms)
         { return new Gedi04bRaster(L, _parms); }
 
-        virtual ~Gedi04bRaster (void) {}
-
     protected:
-
 
         /*--------------------------------------------------------------------
          * Methods
@@ -69,12 +66,6 @@ class Gedi04bRaster: public GeoRaster
                     std::string(_parms->asset->getPath()).append("/").append(_parms->asset->getIndex()).c_str(),
                     TimeLib::datetime2gps(2021, 8, 4),
                     true /* Data is elevation */) {}
-
-    private:
-
-        /*--------------------------------------------------------------------
-         * Data
-         *--------------------------------------------------------------------*/
 };
 
 #endif  /* __gedi04b_raster__ */


### PR DESCRIPTION
Here are my updates for the proj_pipeline and the aoi_bbox parameters.  This is the list of changes:

* proj_pipeline didn't need anything on the client side, if it is supplied in the request dictionary, it will just get passed through
* fixed a memory leak with proj_pipeline not getting deallocated
* added the aoi_bbox parameter to GeoParms; needed to move the bbox_t typedef into GeoParms.h and then import it into the GdalRaster.h namespace
* removed unneeded virtual destructors from the GEDI rasters
* added poly2bbox helper function in raster.py module of python client

In order to use the aoi_bbox parameter, you can see the sliderule-python/examples/gedi_l3_sample.ipynb notebook for a working example, but for convenience, here is a quick example:
```python
from sliderule import sliderule, raster
region = sliderule.toregion('grandmesa.geojson')
bbox = raster.poly2bbox(region["poly"])
parms = { 
          "poly": region['poly'],
          "samples": {"gedi": {"asset": "gedil3-elevation", "aoi_bbox": bbox}} 
}
```