### PR TITLE
enabled gdal multirange, needs ulimit -n 8192

### DIFF
--- a/packages/geo/geo.cpp
+++ b/packages/geo/geo.cpp
@@ -183,12 +183,8 @@ static void configGDAL(void)
      * which is not supported by a majority of servers (including AWS S3 or Google GCS).
      * SERIAL means that each range will be requested sequentially.
      * YES means that each range will be requested in parallel, using HTTP/2 multiplexing or several HTTP connections.
-     *
-     * NOTE: if set to YES, multirange reads cause errors when multiple reader threads read their data sets.
-     *       Perfromed tests with 200 reader threads each reading 16MB and on average 14 to 16 readers failed.
-     *       setting it to SERIAL fixed the problem.
      */
-    CPLSetConfigOption("GDAL_HTTP_MULTIRANGE", "SERIAL");
+    CPLSetConfigOption("GDAL_HTTP_MULTIRANGE", "YES");
 
     /*
      * Tells GDAL to merge consecutive range GET requests.
@@ -196,7 +192,7 @@ static void configGDAL(void)
      * Only applies when GDAL_HTTP_MULTIRANGE is YES.
      * Defines if ranges of a single ReadMultiRange() request that are consecutive should be merged into a single request.
      */
-    CPLSetConfigOption("GDAL_HTTP_MERGE_CONSECUTIVE_RANGES", "NO");
+    CPLSetConfigOption("GDAL_HTTP_MERGE_CONSECUTIVE_RANGES", "YES");
 
     /*
      * When set to YES, this attempts to download multiple range requests in parallel, reusing the same TCP connection.

--- a/targets/slideruleearth-aws/docker-compose.yml
+++ b/targets/slideruleearth-aws/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     entrypoint: /usr/local/bin/sliderule /usr/local/etc/sliderule/server.lua /usr/local/etc/sliderule/config.json
     stdin_open: true # docker run -i
     tty: true # docker run -t
+    ulimits:
+      nofile:
+        soft: "8192"
     volumes:
       - /etc/ssl/certs:/etc/ssl/certs
       - /data:/data

--- a/targets/slideruleearth-aws/terraform/cluster/docker-compose-sliderule.yml
+++ b/targets/slideruleearth-aws/terraform/cluster/docker-compose-sliderule.yml
@@ -8,6 +8,9 @@ services:
     entrypoint: /usr/local/bin/sliderule /usr/local/etc/sliderule/server.lua /usr/local/etc/sliderule/config.json
     stdin_open: true # docker run -i
     tty: true # docker run -t
+    ulimits:
+      nofile:
+        soft: "8192"
     volumes:
       - /etc/ssl/certs:/etc/ssl/certs
       - /data:/data


### PR DESCRIPTION
GDAL_HTTP_MULTIRANGE has been enabled but it requires larger than default per process max file descriptor limit. 
On ubuntu add entry to  /etc/security/limits.conf
* soft nofile 8192

Do something similar for docker images.

With multirange enabled GDAL curl driver will open several tcp sockets and request ranges data over multiple connections. This can speed up downloads up to 25% to 30% for some data sets (ESA worldcover). 

With multirange enabled and default nofile set to 1024 both selftest and subset_perf_test fail. They should pass after nofile limit has been increased. 