### PR TITLE
Verbose logging more convenient

### DIFF
--- a/clients/python/sliderule/earthdata.py
+++ b/clients/python/sliderule/earthdata.py
@@ -34,21 +34,18 @@ import json
 import ssl
 import urllib.request
 import requests
-import logging
 import numpy
 import geopandas
 from datetime import datetime
 from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry import Polygon
+from sliderule import logger
 import sliderule
 
 
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-# create logger
-logger = logging.getLogger(__name__)
 
 # profiling times for each major function
 profiles = {}

--- a/clients/python/sliderule/gedi.py
+++ b/clients/python/sliderule/gedi.py
@@ -32,14 +32,11 @@ import logging
 import numpy
 import geopandas
 import sliderule
-from sliderule import earthdata
+from sliderule import earthdata, logger
 
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-# create logger
-logger = logging.getLogger(__name__)
 
 # profiling times for each major function
 profiles = {}

--- a/clients/python/sliderule/h5.py
+++ b/clients/python/sliderule/h5.py
@@ -28,15 +28,13 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import time
-import logging
 import numpy
 import sliderule
+from sliderule import logger
 
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-logger = logging.getLogger(__name__)
 
 profiles = {}
 

--- a/clients/python/sliderule/icesat2.py
+++ b/clients/python/sliderule/icesat2.py
@@ -32,14 +32,11 @@ import logging
 import numpy
 import geopandas
 import sliderule
-from sliderule import earthdata
+from sliderule import earthdata, logger
 
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-# create logger
-logger = logging.getLogger(__name__)
 
 # profiling times for each major function
 profiles = {}

--- a/clients/python/sliderule/io.py
+++ b/clients/python/sliderule/io.py
@@ -29,11 +29,11 @@
 
 import sys
 import json
-import logging
 import warnings
 import datetime
 import geopandas
 import numpy as np
+from sliderule import logger
 
 # imports with warnings if not present
 try:
@@ -404,8 +404,8 @@ def to_json(filename, **kwargs):
     with open(filename, 'w') as fid:
         json.dump(output, fid)
     # print the filename and dictionary structure
-    logging.info(filename)
-    logging.info(list(output.keys()))
+    logger.info(filename)
+    logger.info(list(output.keys()))
 
 # read request parameters and regions from JSON
 def from_json(filename, **kwargs):
@@ -413,8 +413,8 @@ def from_json(filename, **kwargs):
     with open(filename, 'r') as fid:
         attributes = json.load(fid)
     # print the filename and dictionary structure
-    logging.info(filename)
-    logging.info(list(attributes.keys()))
+    logger.info(filename)
+    logger.info(list(attributes.keys()))
     # try to get the sliderule adjustable parameters
     SRparams = ['H_min_win', 'atl08_class', 'atl03_quality', 'ats', 'cnf',
         'cnt', 'len', 'maxi', 'res', 'sigma_r_max', 'srt', 'yapc']
@@ -527,8 +527,8 @@ def to_nc(gdf, filename, **kwargs):
         setattr(fileID, 'poly{0:d}_x'.format(i), json.dumps(lon))
         setattr(fileID, 'poly{0:d}_y'.format(i), json.dumps(lat))
     # Output netCDF structure information
-    logging.info(filename)
-    logging.info(list(fileID.variables.keys()))
+    logger.info(filename)
+    logger.info(list(fileID.variables.keys()))
     # Closing the netCDF file
     fileID.close()
     warnings.filterwarnings("default")
@@ -709,8 +709,8 @@ def write_pytables(df, filename, attributes, **kwargs):
         setattr(fileID.root._v_attrs, f'poly{i:d}_x', json.dumps(lon))
         setattr(fileID.root._v_attrs, f'poly{i:d}_y', json.dumps(lat))
     # Output HDF5 structure information
-    logging.info(filename)
-    logging.info(fileID.get_storer('sliderule_segments').non_index_axes[0][1])
+    logger.info(filename)
+    logger.info(fileID.get_storer('sliderule_segments').non_index_axes[0][1])
     # Closing the HDF5 file
     fileID.close()
 
@@ -790,8 +790,8 @@ def write_h5py(df, filename, attributes, **kwargs):
         fileID.attrs[f'poly{i:d}_x'] = json.dumps(lon)
         fileID.attrs[f'poly{i:d}_y'] = json.dumps(lat)
     # Output HDF5 structure information
-    logging.info(filename)
-    logging.info(list(fileID.keys()))
+    logger.info(filename)
+    logger.info(list(fileID.keys()))
     # Closing the HDF5 file
     fileID.close()
 

--- a/clients/python/sliderule/ipxapi.py
+++ b/clients/python/sliderule/ipxapi.py
@@ -27,15 +27,7 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from sliderule import icesat2, sliderule
-import logging
-
-###############################################################################
-# GLOBALS
-###############################################################################
-
-# create logger
-logger = logging.getLogger(__name__)
+from sliderule import icesat2, sliderule, logger
 
 ###############################################################################
 # APIs

--- a/clients/python/sliderule/ipysliderule.py
+++ b/clients/python/sliderule/ipysliderule.py
@@ -31,7 +31,6 @@ import os
 import io
 import sys
 import copy
-import logging
 import datetime
 import traceback
 import numpy as np
@@ -43,6 +42,7 @@ import matplotlib.colorbar
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 from traitlets.utils.bunch import Bunch
+from sliderule import logger
 import sliderule.io
 
 # imports with warnings if not present
@@ -1334,13 +1334,13 @@ class widgets:
         try:
             rgt = int(self.rgt.value)
         except:
-            logging.critical(f"RGT {self.rgt.value} is invalid")
+            logger.critical(f"RGT {self.rgt.value} is invalid")
             return "0"
         # verify ground track values
         if (rgt >= 1) and (rgt <= 1387):
             return self.rgt.value
         else:
-            logging.critical(f"RGT {self.rgt.value} is outside available range")
+            logger.critical(f"RGT {self.rgt.value} is outside available range")
             return "0"
 
     @property
@@ -1384,7 +1384,7 @@ class widgets:
         if (self.cycle.value in all_cycles):
             return self.cycle.value
         else:
-            logging.critical(f"Cycle {self.cycle.value} is outside available range")
+            logger.critical(f"Cycle {self.cycle.value} is outside available range")
             return "0"
 
     @property
@@ -2071,14 +2071,14 @@ class leaflet:
                     # simply attempt to add the layer or control
                     self.map.add(layer)
             except ipyleaflet.LayerException as e:
-                logging.info(f"Layer {layer} already on map")
+                logger.info(f"Layer {layer} already on map")
                 pass
             except ipyleaflet.ControlException as e:
-                logging.info(f"Control {layer} already on map")
+                logger.info(f"Control {layer} already on map")
                 pass
             except Exception as e:
-                logging.critical(f"Could add layer {layer}")
-                logging.error(traceback.format_exc())
+                logger.critical(f"Could add layer {layer}")
+                logger.error(traceback.format_exc())
                 pass
 
     # remove map layers
@@ -2126,14 +2126,14 @@ class leaflet:
                     # simply attempt to remove the layer or control
                     self.map.remove(layer)
             except ipyleaflet.LayerException as e:
-                logging.info(f"Layer {layer} already removed from map")
+                logger.info(f"Layer {layer} already removed from map")
                 pass
             except ipyleaflet.ControlException as e:
-                logging.info(f"Control {layer} already removed from map")
+                logger.info(f"Control {layer} already removed from map")
                 pass
             except Exception as e:
-                logging.critical(f"Could not remove layer {layer}")
-                logging.error(traceback.format_exc())
+                logger.critical(f"Could not remove layer {layer}")
+                logger.error(traceback.format_exc())
                 pass
 
     # handle cursor movements for label
@@ -2214,7 +2214,7 @@ class leaflet:
         kwargs.setdefault('colorbar', True)
         kwargs.setdefault('position', 'topright')
         # add warning that function is deprecated
-        logging.critical(f"Deprecated. Will be removed in a future release")
+        logger.critical(f"Deprecated. Will be removed in a future release")
         # remove any prior instances of a data layer
         if self.geojson is not None:
             self.map.remove(self.geojson)
@@ -2609,14 +2609,14 @@ class LeafletMap:
         try:
             self.map.remove(layer)
         except ipyleaflet.LayerException as e:
-            logging.info(f"Layer {layer} already removed from map")
+            logger.info(f"Layer {layer} already removed from map")
             pass
         except ipyleaflet.ControlException as e:
-            logging.info(f"Control {layer} already removed from map")
+            logger.info(f"Control {layer} already removed from map")
             pass
         except Exception as e:
-            logging.critical(f"Could not remove layer {layer}")
-            logging.error(traceback.format_exc())
+            logger.critical(f"Could not remove layer {layer}")
+            logger.error(traceback.format_exc())
             pass
 
     # add colorbar widget to leaflet map

--- a/clients/python/sliderule/raster.py
+++ b/clients/python/sliderule/raster.py
@@ -27,7 +27,6 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import logging
 import numpy
 import base64
 import sliderule
@@ -37,8 +36,6 @@ from shapely.geometry import Polygon
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-logger = logging.getLogger(__name__)
 
 profiles = {}
 

--- a/clients/python/sliderule/sliderule.py
+++ b/clients/python/sliderule/sliderule.py
@@ -40,7 +40,7 @@ import warnings
 import numpy
 import geopandas
 from shapely.geometry import Polygon
-from datetime import datetime, timedelta
+from datetime import datetime
 from sliderule import version
 
 ###############################################################################
@@ -70,11 +70,10 @@ ps_token_exp = None
 
 MAX_PS_CLUSTER_WAIT_SECS = 600
 
-verbose = False
-
 request_timeout = (10, 120) # (connection, read) in seconds
 
 logger = logging.getLogger(__name__)
+console = None
 
 clustering_enabled = False
 try:
@@ -437,18 +436,16 @@ socket.getaddrinfo = __override_getaddrinfo
 #  __logeventrec
 #
 def __logeventrec(rec):
-    if verbose:
-        eventlogger[rec['level']]('%s' % (rec["attr"]))
+    eventlogger[rec['level']]('%s' % (rec["attr"]))
 
 #
 #  __exceptrec
 #
 def __exceptrec(rec):
-    if verbose:
-        if rec["code"] >= 0:
-            eventlogger[rec["level"]]("Exception <%d>: %s", rec["code"], rec["text"])
-        else:
-            eventlogger[rec["level"]]("%s", rec["text"])
+    if rec["code"] >= 0:
+        eventlogger[rec["level"]]("Exception <%d>: %s", rec["code"], rec["text"])
+    else:
+        eventlogger[rec["level"]]("%s", rec["text"])
 
 #
 #  _arrowrec
@@ -645,7 +642,7 @@ def init (url=PUBLIC_URL, verbose=False, loglevel=logging.INFO, organization=0, 
         url:            str
                         the IP address or hostname of the SlideRule service (slidereearth.io by default)
         verbose:        bool
-                        whether or not user level log messages received from SlideRule generate a Python log message
+                        sets up console logger as a convenience to user so all logs are printed to screen
         loglevel:       int
                         minimum severity of log message to output
         organization:   str
@@ -669,11 +666,12 @@ def init (url=PUBLIC_URL, verbose=False, loglevel=logging.INFO, organization=0, 
         >>> import sliderule
         >>> sliderule.init()
     '''
-    set_verbose(verbose)
-    logger.setLevel(loglevel)
-    set_url(url) # configure domain
+    #  massage function parameters
     if organization == 0:
         organization = PUBLIC_ORG
+    # configure client
+    set_verbose(verbose, loglevel)
+    set_url(url) # configure domain
     authenticate(organization) # configure credentials (if any) for organization
     scaleout(desired_nodes, time_to_live, bypass_dns) # set cluster to desired number of nodes (if permitted based on credentials)
     return check_version(plugins=plugins) # verify compatibility between client and server versions
@@ -812,36 +810,53 @@ def set_url (url):
 #
 #  set_verbose
 #
-def set_verbose (enable):
+def set_verbose (enable, loglevel=logging.INFO):
     '''
-    Configure sliderule package for verbose logging
+    Sets up a console logger to print log messages to screen
+
+    If you want more control over the behavior of the log messages being captured, do not call this function but instead 
+    create and configure a Python log handler of your own and attach it to `sliderule.logger`.
 
     Parameters
     ----------
         enable:     bool
-                    whether or not user level log messages received from SlideRule generate a Python log message
+                    True: creates console logger if it doesn't exist, False: destroys console logger if it does exist
+
+        loglevel:       int
+                        minimum severity of log message to output
 
     Examples
     --------
         >>> import sliderule
-        >>> sliderule.set_verbose(True)
-
-        The default behavior of Python log messages is for them to be displayed to standard output.
-        If you want more control over the behavior of the log messages being display, create and configure a Python log handler as shown below:
-
-        >>> # import packages
-        >>> import logging
-        >>> from sliderule import sliderule
-        >>> # Configure Logging
-        >>> sliderule_logger = logging.getLogger("sliderule.sliderule")
-        >>> sliderule_logger.setLevel(logging.INFO)
-        >>> # Create Console Output
-        >>> ch = logging.StreamHandler()
-        >>> ch.setLevel(logging.INFO)
-        >>> sliderule_logger.addHandler(ch)
+        >>> sliderule.set_verbose(True, loglevel=logging.INFO)
     '''
-    global verbose
-    verbose = (enable == True)
+    global console, logger
+    # massage loglevel parameter if passed in as a string
+    if loglevel == "DEBUG":
+        loglevel = logging.DEBUG
+    elif loglevel == "INFO":
+        loglevel = logging.INFO
+    elif loglevel == "WARNING":
+        loglevel = logging.WARNING
+    elif loglevel == "WARN":
+        loglevel = logging.WARN
+    elif loglevel == "ERROR":
+        loglevel = logging.ERROR
+    elif loglevel == "FATAL":
+        loglevel = logging.FATAL
+    elif loglevel == "CRITICAL":
+        loglevel = logging.CRITICAL
+    # enable/disable logging to console
+    if (enable == True) and (console == None):
+        console = logging.StreamHandler()
+        logger.addHandler(console)
+    elif (enable == False) and (console != None):
+        logger.removeHandler(console)
+        console = None
+    # always set level to requested
+    logger.setLevel(loglevel)
+    if console != None:
+        console.setLevel(loglevel)
 
 #
 # set_rqst_timeout

--- a/clients/python/sliderule/swot.py
+++ b/clients/python/sliderule/swot.py
@@ -30,16 +30,12 @@
 import time
 import logging
 import numpy
-import geopandas
 import sliderule
-from sliderule import earthdata
+from sliderule import earthdata, logger
 
 ###############################################################################
 # GLOBALS
 ###############################################################################
-
-# create logger
-logger = logging.getLogger(__name__)
 
 # profiling times for each major function
 profiles = {}

--- a/clients/python/utils/benchmark.py
+++ b/clients/python/utils/benchmark.py
@@ -56,18 +56,8 @@ if args.organization == "None":
     args.desired_nodes = None
     args.time_to_live = None
 
-# Initialize Log Level
-loglevel = logging.CRITICAL
-if args.loglvl == "ERROR":
-    loglevel = logging.ERROR
-elif args.loglvl == "INFO":
-    loglevel = logging.INFO
-elif args.loglvl == "DEBUG":
-    loglevel = logging.DEBUG
-logging.basicConfig(level=loglevel)
-
 # Initialize SlideRule Client
-sliderule.init(args.domain, verbose=args.verbose, organization=args.organization, desired_nodes=args.desired_nodes, time_to_live=args.time_to_live)
+sliderule.init(args.domain, verbose=args.verbose, loglevel=args.loglvl, organization=args.organization, desired_nodes=args.desired_nodes, time_to_live=args.time_to_live)
 
 # Generate Region Polygon
 region = sliderule.toregion(args.aoi)


### PR DESCRIPTION
This PR simplifies the user experience for getting basic messages logged to the console when calling SlideRule APIs.

**Previously**
* Each SlideRule Python client module had it's own logger (except for a few which used the global logger)
* The _init_ function's `verbose` setting enabled/disabled the logging of messages received from the server
* The _init_ function's `loglevel` setting changed the logging level for the `sliderule` module's logger
* It was on the user to create a log handler either manually or by using `logging.basicConfig`

This design gives the user  full control - they can create individual handlers for the log messages generated in each of the submodules of the SlideRule Python client, and manage exactly how they are displayed.  It also separates out the log messages coming from the server (which typically are a lot), from the log messages generated by the client (which typically are a few).

But in the vast majority of the cases, a user either wants to see messages printed to their screen, or they don't want to see anything.  And the `verbose` option intuitively should control this.

**Changes in this PR**
* The SlideRule Python client uses a single logger created in the core module
* Server log messages are always logged at the level they are generated at
* The _init_ function's `verbose` setting will automatically create a console logger which will display all log messages of a sufficient log level to the screen
* The _init_ function's `loglevel` setting will always change the global log level, and when a console logger is created (i.e. when verbose is set to True), then it will change the console logger's log level as well.
* If the user wants control over how the logger is created, they can always set `verbose` to False (which is the default), and create their own log handler and attach it to `sliderule.logger`