### PR TITLE
support POST to endpoints that do not stream

### DIFF
--- a/clients/nodejs/sliderule/core.js
+++ b/clients/nodejs/sliderule/core.js
@@ -409,14 +409,14 @@ export function source(api, parm=null, stream=false, callbacks={}) {
   const options = {
     host: sysConfig.organization && (sysConfig.organization + '.' + sysConfig.domain) || sysConfig.domain,
     path: '/source/' + api,
-    method: stream && 'POST' || 'GET',
+    method: 'POST',
   };
 
   // Build Body
   let body = null;
   if (parm != null) {
     body = JSON.stringify(parm);
-    options["headers"] = {'Content-Type': 'application/json', 'Content-Length': body.length};
+    options["headers"] = {'Content-Type': 'application/json', 'Content-Length': body.length, 'x-sliderule-streaming': stream && 1 || 0};
   }
 
   // Make API Request

--- a/clients/nodejs/sliderule/package-lock.json
+++ b/clients/nodejs/sliderule/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliderule/sliderule",
-  "version": "4.1.0",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliderule/sliderule",
-      "version": "4.1.0",
+      "version": "4.2.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/clients/nodejs/utils/main.mjs
+++ b/clients/nodejs/utils/main.mjs
@@ -1,6 +1,9 @@
 import {core,h5coro,icesat2} from '../sliderule/index.js';
 
-core.init({});
+import http from 'http'
+core.init({domain:"localhost", organization: null, protocol: http});
+
+//core.init({});
 
 icesat2.atl06p(
     { "cnf": "atl03_high",

--- a/packages/core/EndpointObject.h
+++ b/packages/core/EndpointObject.h
@@ -126,6 +126,7 @@ class EndpointObject: public LuaObject
         typedef struct {
             EndpointObject*     endpoint;
             Request*            request;
+            bool                streaming;
         } info_t;
 
         /*--------------------------------------------------------------------


### PR DESCRIPTION
This is to support javascript fetch which does not allow GET requests to have a body.