### PR TITLE
geo package cleanup for gdal/ogr header files

### DIFF
--- a/packages/geo/GdalRaster.cpp
+++ b/packages/geo/GdalRaster.cpp
@@ -394,7 +394,7 @@ uint8_t* GdalRaster::getPixels(uint32_t ulx, uint32_t uly, uint32_t _xsize, uint
             if(parms->sampling_algo != GRIORA_NearestNeighbour)
             {
                 INIT_RASTERIO_EXTRA_ARG(args);
-                args.eResampleAlg = parms->sampling_algo;
+                args.eResampleAlg = static_cast<GDALRIOResampleAlg>(parms->sampling_algo);
                 argsPtr = &args;
             }
             err = band->RasterIO(GF_Read, ulx, uly, _xsize, _ysize, data, _xsize, _ysize, dtype, 0, 0, argsPtr);
@@ -683,7 +683,7 @@ void GdalRaster::resamplePixel(const OGRPoint* poi, RasterSample* sample)
 
         GDALRasterIOExtraArg args;
         INIT_RASTERIO_EXTRA_ARG(args);
-        args.eResampleAlg = parms->sampling_algo;
+        args.eResampleAlg = static_cast<GDALRIOResampleAlg>(parms->sampling_algo);
 
         bool validWindow = containsWindow(_x, _y, xsize, ysize, windowSize);
         if(validWindow)
@@ -726,7 +726,7 @@ void GdalRaster::computeZonalStats(const OGRPoint* poi, RasterSample* sample)
 
         GDALRasterIOExtraArg args;
         INIT_RASTERIO_EXTRA_ARG(args);
-        args.eResampleAlg = parms->sampling_algo;
+        args.eResampleAlg = static_cast<GDALRIOResampleAlg>(parms->sampling_algo);
         samplesArray = new double[windowSize*windowSize];
 
         bool validWindow = containsWindow(newx, newy, xsize, ysize, windowSize);

--- a/packages/geo/GeoParms.cpp
+++ b/packages/geo/GeoParms.cpp
@@ -258,7 +258,7 @@ GeoParms::GeoParms (lua_State* L, int index, bool asset_required):
             if(field_provided)
             {
                 bands = new band_list_t::Iterator(bands_list);
-                mlog(DEBUG, "Setting %s to user provided selection", BANDS);                
+                mlog(DEBUG, "Setting %s to user provided selection", BANDS);
             }
             lua_pop(L, 1);
 
@@ -340,17 +340,17 @@ void GeoParms::cleanup (void)
 /*----------------------------------------------------------------------------
  * str2algo
  *----------------------------------------------------------------------------*/
-GDALRIOResampleAlg GeoParms::str2algo (const char* str)
+int GeoParms::str2algo (const char* str)
 {
-    if(!str)                                            return GRIORA_NearestNeighbour;
-    if(StringLib::match(str, NEARESTNEIGHBOUR_ALGO))    return GRIORA_NearestNeighbour;
-    if(StringLib::match(str, BILINEAR_ALGO))            return GRIORA_Bilinear;
-    if(StringLib::match(str, CUBIC_ALGO))               return GRIORA_Cubic;
-    if(StringLib::match(str, CUBICSPLINE_ALGO))         return GRIORA_CubicSpline;
-    if(StringLib::match(str, LANCZOS_ALGO))             return GRIORA_Lanczos;
-    if(StringLib::match(str, AVERAGE_ALGO))             return GRIORA_Average;
-    if(StringLib::match(str, MODE_ALGO))                return GRIORA_Mode;
-    if(StringLib::match(str, GAUSS_ALGO))               return GRIORA_Gauss;
+    if(!str)                                         return static_cast<int>(GRIORA_NearestNeighbour);
+    if(StringLib::match(str, NEARESTNEIGHBOUR_ALGO)) return static_cast<int>(GRIORA_NearestNeighbour);
+    if(StringLib::match(str, BILINEAR_ALGO))         return static_cast<int>(GRIORA_Bilinear);
+    if(StringLib::match(str, CUBIC_ALGO))            return static_cast<int>(GRIORA_Cubic);
+    if(StringLib::match(str, CUBICSPLINE_ALGO))      return static_cast<int>(GRIORA_CubicSpline);
+    if(StringLib::match(str, LANCZOS_ALGO))          return static_cast<int>(GRIORA_Lanczos);
+    if(StringLib::match(str, AVERAGE_ALGO))          return static_cast<int>(GRIORA_Average);
+    if(StringLib::match(str, MODE_ALGO))             return static_cast<int>(GRIORA_Mode);
+    if(StringLib::match(str, GAUSS_ALGO))            return static_cast<int>(GRIORA_Gauss);
     throw RunTimeException(CRITICAL, RTE_ERROR, "Invalid sampling algorithm: %s:", str);
 }
 

--- a/packages/geo/GeoParms.h
+++ b/packages/geo/GeoParms.h
@@ -44,8 +44,6 @@
  * INCLUDES
  ******************************************************************************/
 
-#include <gdal.h>
-
 #include "OsApi.h"
 #include "LuaObject.h"
 #include "Asset.h"
@@ -122,7 +120,7 @@ class GeoParms: public LuaObject
         * Data
         *--------------------------------------------------------------------*/
 
-        GDALRIOResampleAlg      sampling_algo;
+        int                     sampling_algo;
         int                     sampling_radius;
         bool                    zonal_stats;
         bool                    flags_file;
@@ -156,14 +154,14 @@ class GeoParms: public LuaObject
         * Methods
         *--------------------------------------------------------------------*/
 
-        void                        cleanup         (void);
-        static GDALRIOResampleAlg   str2algo        (const char* str);
-        void                        getLuaBands     (lua_State* L, int index, bool* provided);
-        void                        getAoiBbox      (lua_State* L, int index, bool* provided);
+        void       cleanup         (void);
+        static int str2algo        (const char* str);
+        void       getLuaBands     (lua_State* L, int index, bool* provided);
+        void       getAoiBbox      (lua_State* L, int index, bool* provided);
 
-        static int                  luaAssetName    (lua_State* L);
-        static int                  luaAssetRegion  (lua_State* L);
-        static int                  luaSetKeySpace  (lua_State* L);
+        static int luaAssetName    (lua_State* L);
+        static int luaAssetRegion  (lua_State* L);
+        static int luaSetKeySpace  (lua_State* L);
 };
 
 #endif  /* __geo_parms__ */

--- a/packages/geo/GeoRaster.cpp
+++ b/packages/geo/GeoRaster.cpp
@@ -40,6 +40,44 @@
  ******************************************************************************/
 
 /*----------------------------------------------------------------------------
+ * init
+ *----------------------------------------------------------------------------*/
+void GeoRaster::init (void)
+{
+}
+
+/*----------------------------------------------------------------------------
+ * deinit
+ *----------------------------------------------------------------------------*/
+void GeoRaster::deinit (void)
+{
+}
+
+/*----------------------------------------------------------------------------
+ * Constructor
+ *----------------------------------------------------------------------------*/
+GeoRaster::GeoRaster(lua_State *L, GeoParms* _parms, const std::string& _fileName, double _gpsTime, bool dataIsElevation, GdalRaster::overrideCRS_t cb):
+    RasterObject(L, _parms),
+    raster(_parms, _fileName, _gpsTime, fileDictAdd(_fileName), dataIsElevation, cb)
+{
+    /* Add Lua Functions */
+    LuaEngine::setAttrFunc(L, "dim", luaDimensions);
+    LuaEngine::setAttrFunc(L, "bbox", luaBoundingBox);
+    LuaEngine::setAttrFunc(L, "cell", luaCellSize);
+
+    /* Establish Credentials */
+    GdalRaster::initAwsAccess(_parms);
+}
+
+/*----------------------------------------------------------------------------
+ * Destructor
+ *----------------------------------------------------------------------------*/
+GeoRaster::~GeoRaster(void)
+{
+}
+
+
+/*----------------------------------------------------------------------------
  * getSamples
  *----------------------------------------------------------------------------*/
 uint32_t GeoRaster::getSamples(const MathLib::point_3d_t& point, int64_t gps, List<RasterSample*>& slist, void* param)
@@ -115,7 +153,6 @@ uint32_t GeoRaster::getSubsets(const MathLib::extent_t& extent, int64_t gps, Lis
     return raster.getSSerror();
 }
 
-
 /*----------------------------------------------------------------------------
  * getPixels
  *----------------------------------------------------------------------------*/
@@ -138,30 +175,6 @@ uint8_t* GeoRaster::getPixels(uint32_t ulx, uint32_t uly, uint32_t xsize, uint32
 
     return data;
 }
-
-/*----------------------------------------------------------------------------
- * Constructor
- *----------------------------------------------------------------------------*/
-GeoRaster::GeoRaster(lua_State *L, GeoParms* _parms, const std::string& _fileName, double _gpsTime, bool dataIsElevation, GdalRaster::overrideCRS_t cb):
-    RasterObject(L, _parms),
-    raster(_parms, _fileName, _gpsTime, fileDictAdd(_fileName), dataIsElevation, cb)
-{
-    /* Add Lua Functions */
-    LuaEngine::setAttrFunc(L, "dim", luaDimensions);
-    LuaEngine::setAttrFunc(L, "bbox", luaBoundingBox);
-    LuaEngine::setAttrFunc(L, "cell", luaCellSize);
-
-    /* Establish Credentials */
-    GdalRaster::initAwsAccess(_parms);
-}
-
-/*----------------------------------------------------------------------------
- * Destructor
- *----------------------------------------------------------------------------*/
-GeoRaster::~GeoRaster(void)
-{
-}
-
 
 /******************************************************************************
  * PROTECTED METHODS

--- a/packages/geo/GeoRaster.h
+++ b/packages/geo/GeoRaster.h
@@ -58,6 +58,9 @@ class GeoRaster: public RasterObject
          * Methods
          *--------------------------------------------------------------------*/
 
+        static void   init       (void);
+        static void   deinit     (void);
+
                       GeoRaster  (lua_State* L, GeoParms* _parms, const std::string& _fileName, double _gpsTime, bool dataIsElevation, GdalRaster::overrideCRS_t cb=NULL);
         virtual      ~GeoRaster  (void);
         uint32_t      getSamples (const MathLib::point_3d_t& point, int64_t gps, List<RasterSample*>& slist, void* param=NULL) final;

--- a/packages/geo/RasterObject.h
+++ b/packages/geo/RasterObject.h
@@ -36,8 +36,6 @@
  * INCLUDES
  ******************************************************************************/
 
-#include <vector>
-#include <ogr_geometry.h>
 #include "LuaObject.h"
 #include "MathLib.h"
 #include "List.h"

--- a/packages/geo/RasterSubset.cpp
+++ b/packages/geo/RasterSubset.cpp
@@ -37,6 +37,7 @@
 #include "EventLib.h"
 #include "RasterObject.h"
 #include "RasterSubset.h"
+#include <ogr_geometry.h>
 
 /******************************************************************************
  * STATIC DATA

--- a/packages/geo/geo.cpp
+++ b/packages/geo/geo.cpp
@@ -39,6 +39,11 @@
 #include "UT_RasterSubset.h"
 #endif
 
+#include "GeoRaster.h"
+#include "GeoIndexedRaster.h"
+#include "GeoJsonRaster.h"
+#include "GeoUserRaster.h"
+
 #include <gdal.h>
 #include <cpl_conv.h>
 #include <proj.h>
@@ -305,6 +310,7 @@ void initgeo (void)
     test_projlib();
 
     /* Initialize Modules */
+    GeoRaster::init();
     GeoIndexedRaster::init();
     RasterSampler::init();
     GeoLib::init();
@@ -329,6 +335,7 @@ void initgeo (void)
 
 void deinitgeo (void)
 {
+    GeoRaster::deinit();
     GeoIndexedRaster::deinit();
     RasterSampler::deinit();
     GDALDestroy();

--- a/packages/geo/geo.h
+++ b/packages/geo/geo.h
@@ -36,16 +36,9 @@
  * INCLUDES
  ******************************************************************************/
 
-#include "GdalRaster.h"
-#include "GeoIndexedRaster.h"
-#include "GeoJsonRaster.h"
 #include "GeoLib.h"
 #include "GeoParms.h"
-#include "GeoRaster.h"
-#include "GeoUserRaster.h"
 #include "RasterObject.h"
-#include "RasterObject.h"
-#include "RasterSample.h"
 #include "RasterSampler.h"
 #include "RasterSubset.h"
 

--- a/plugins/gedi/CMakeLists.txt
+++ b/plugins/gedi/CMakeLists.txt
@@ -16,7 +16,6 @@ set_target_properties (gedi PROPERTIES CXX_STANDARD ${CXX_VERSION})
 
 # Prerequisites #
 find_package (Lua "5.3")
-find_package (GDAL)
 
 # Build Information #
 execute_process (COMMAND git --work-tree ${PROJECT_SOURCE_DIR}/../.. --git-dir ${PROJECT_SOURCE_DIR}/../../.git describe --abbrev --dirty --always --tags --long OUTPUT_VARIABLE BUILDINFO)

--- a/plugins/icesat2/CMakeLists.txt
+++ b/plugins/icesat2/CMakeLists.txt
@@ -16,7 +16,6 @@ set_target_properties (icesat2 PROPERTIES CXX_STANDARD ${CXX_VERSION})
 
 # Prerequisites #
 find_package (Lua "5.3")
-find_package (GDAL)
 
 # Build Information #
 execute_process (COMMAND git --work-tree ${PROJECT_SOURCE_DIR}/../.. --git-dir ${PROJECT_SOURCE_DIR}/../../.git describe --abbrev --dirty --always --tags --long OUTPUT_VARIABLE BUILDINFO)


### PR DESCRIPTION
SlideRule users who don't use geo package are currently required to install GDAL. I cleaned up geo package header files for dependencies on gdal/ogr. Plugins which don't use geo/raster code should now build without GDAL locally installed.